### PR TITLE
Implement interactive CLI error fixing

### DIFF
--- a/manim_video_generator/__init__.py
+++ b/manim_video_generator/__init__.py
@@ -2,4 +2,4 @@
 Manim Video Generator - CLI tool for creating videos using Gemini 2.5 Flash Thinking and Manim
 """
 
-__version__ = "1.0.0" 
+__version__ = "1.1.0"

--- a/manim_video_generator/gemini_client.py
+++ b/manim_video_generator/gemini_client.py
@@ -10,54 +10,54 @@ class GeminiClient:
     def __init__(self, api_key: str = None):
         self.api_key = api_key or os.getenv("GEMINI_API_KEY")
         if not self.api_key:
-            raise ValueError("GEMINI_API_KEY не найден в переменных окружения")
+            raise ValueError("GEMINI_API_KEY not found in environment variables")
         
         genai.configure(api_key=self.api_key)
         self.model = genai.GenerativeModel("gemini-2.0-flash-thinking-exp")
-        logger.info("Gemini client инициализирован")
+        logger.info("Gemini client initialized")
 
     def generate_manim_code(self, user_request: str) -> str:
-        """Генерирует код Manim на основе запроса пользователя"""
+        """Generate Manim code based on the user's request"""
         prompt = f"""
-Ты - эксперт по библиотеке Manim для создания математических анимаций. 
-Пользователь просит: {user_request}
+You are an expert on the Manim library for creating mathematical animations.
+The user requests: {user_request}
 
-Напиши ТОЛЬКО код Python с использованием Manim, который создаст видео согласно запросу.
-Требования:
-1. Класс должен наследоваться от Scene
-2. Используй self.play() для анимаций
-3. Добавь self.wait() в конце
-4. Не добавляй никаких комментариев или объяснений
-5. Код должен быть готов к выполнению
-6. Импортируй все необходимые модули из manim
-7. ВАЖНО: Предпочитай Text() вместо MathTex() для текста, так как MathTex требует LaTeX
-8. Для математических формул используй обычный Text() с Unicode символами или простые геометрические фигуры
+Write ONLY Python code using Manim that will create the requested video.
+Requirements:
+1. The class must inherit from Scene
+2. Use self.play() for animations
+3. Add self.wait() at the end
+4. Do not add any comments or explanations
+5. The code must be ready to run
+6. Import all required modules from manim
+7. IMPORTANT: Prefer Text() instead of MathTex() since MathTex requires LaTeX
+8. For math formulas use plain Text() with Unicode characters or simple shapes
 
-Пример структуры:
+Example structure:
 ```python
 from manim import *
 
 class VideoScene(Scene):
     def construct(self):
-        # Используй Text() для текста
+        # Use Text() for text
         title = Text("a² + b² = c²")
-        # Используй простые фигуры для визуализации
+        # Use simple shapes for visualization
         square = Square()
         self.play(Write(title))
         self.play(Create(square))
         self.wait()
 ```
 
-Создай видео для запроса: {user_request}
+Create a video for the request: {user_request}
 """
 
-        logger.info(f"Отправляю запрос в Gemini: {user_request}")
+        logger.info(f"Sending request to Gemini: {user_request}")
         response = self.model.generate_content(prompt)
         
-        # Извлекаем код из ответа
+        # Extract code from the response
         code = response.text.strip()
         
-        # Убираем markdown форматирование если есть
+        # Remove markdown formatting if present
         if code.startswith("```python"):
             code = code[9:]
         if code.startswith("```"):
@@ -66,5 +66,39 @@ class VideoScene(Scene):
             code = code[:-3]
         
         code = code.strip()
-        logger.info("Код Manim сгенерирован успешно")
-        return code 
+        logger.info("Manim code generated successfully")
+        return code
+
+    def fix_manim_code(self, current_code: str, error_trace: str, user_hint: str | None = None) -> str:
+        """Fix Manim code using the error trace and optional user hint"""
+        hint_block = f"\nUser hint: {user_hint}" if user_hint else ""
+        prompt = f"""
+You are an assistant that helps fix errors in Manim code.
+
+Current code:
+```python
+{current_code}
+```
+
+Execution error:
+{error_trace}
+{hint_block}
+
+Provide the corrected code. Return ONLY the Python code without explanations.
+"""
+
+        logger.info("Sending code fix request to Gemini")
+        response = self.model.generate_content(prompt)
+
+        fixed = response.text.strip()
+
+        if fixed.startswith("```python"):
+            fixed = fixed[9:]
+        if fixed.startswith("```"):
+            fixed = fixed[3:]
+        if fixed.endswith("```"):
+            fixed = fixed[:-3]
+
+        fixed = fixed.strip()
+        logger.info("Received fixed code from Gemini")
+        return fixed

--- a/manim_video_generator/video_executor.py
+++ b/manim_video_generator/video_executor.py
@@ -10,31 +10,31 @@ class VideoExecutor:
     def __init__(self, output_dir: str = "output"):
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(exist_ok=True)
-        logger.info(f"VideoExecutor инициализирован, папка вывода: {self.output_dir}")
+        logger.info(f"VideoExecutor initialized, output directory: {self.output_dir}")
 
     def execute_manim_code(self, code: str, scene_name: str = "VideoScene") -> Path:
-        """Выполняет код Manim в изолированной среде и возвращает путь к видео"""
+        """Execute Manim code in an isolated environment and return the video path"""
         
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             
-            # Создаем временный файл с кодом
+            # Create a temporary file with the code
             code_file = temp_path / "scene.py"
             with open(code_file, "w", encoding="utf-8") as f:
                 f.write(code)
             
-            logger.info(f"Код записан во временный файл: {code_file}")
+            logger.info(f"Code written to temporary file: {code_file}")
             
-            # Выполняем Manim
+            # Run Manim
             output_file = self._run_manim(code_file, scene_name, temp_path)
             
-            # Копируем результат в папку вывода
+            # Copy the result to the output folder
             final_output = self._copy_to_output(output_file)
             
             return final_output
 
     def _run_manim(self, code_file: Path, scene_name: str, temp_dir: Path) -> Path:
-        """Запускает Manim для рендеринга видео"""
+        """Run Manim to render the video"""
         
         cmd = [
             "manim", "render",
@@ -45,47 +45,47 @@ class VideoExecutor:
             "--output_file", "video.mp4"
         ]
         
-        logger.info(f"Выполняю команду: {' '.join(cmd)}")
+        logger.info(f"Executing command: {' '.join(cmd)}")
         
-        # Выполняем команду в временной директории
+        # Execute the command in the temporary directory
         result = subprocess.run(
             cmd,
             cwd=temp_dir,
             capture_output=True,
             text=True,
-            timeout=300  # 5 минут максимум
+            timeout=300  # 5 minutes max
         )
         
         if result.returncode != 0:
-            logger.error(f"Ошибка выполнения Manim: {result.stderr}")
-            raise RuntimeError(f"Manim завершился с ошибкой: {result.stderr}")
+            logger.error(f"Manim execution error: {result.stderr}")
+            raise RuntimeError(f"Manim exited with error: {result.stderr}")
         
-        logger.info("Manim выполнен успешно")
+        logger.info("Manim executed successfully")
         
-        # Ищем созданное видео
+        # Look for the created video
         media_dir = temp_dir / "media"
         if not media_dir.exists():
-            raise FileNotFoundError("Папка media не найдена после выполнения Manim")
+            raise FileNotFoundError("Media folder not found after running Manim")
         
-        # Ищем mp4 файл рекурсивно
+        # Search for mp4 file recursively
         video_files = list(media_dir.rglob("*.mp4"))
         if not video_files:
-            raise FileNotFoundError("Видеофайл не найден после рендеринга")
+            raise FileNotFoundError("Video file not found after rendering")
         
-        # Берем самый свежий файл
+        # Take the most recent file
         video_file = max(video_files, key=lambda f: f.stat().st_mtime)
-        logger.info(f"Найден видеофайл: {video_file}")
+        logger.info(f"Video file found: {video_file}")
         
         return video_file
 
     def _copy_to_output(self, video_file: Path) -> Path:
-        """Копирует видео в папку вывода с уникальным именем"""
+        """Copy video to the output folder with a unique name"""
         
         import time
         timestamp = int(time.time())
         output_file = self.output_dir / f"video_{timestamp}.mp4"
         
         shutil.copy2(video_file, output_file)
-        logger.info(f"Видео скопировано в: {output_file}")
+        logger.info(f"Video copied to: {output_file}")
         
         return output_file 

--- a/test_example.py
+++ b/test_example.py
@@ -1,93 +1,93 @@
 """
-Простой тест для проверки работы модулей
-Запустите: python test_example.py
+Simple tests to check that modules load correctly.
+Run: python test_example.py
 """
 
 import os
 from pathlib import Path
 
-# Добавляем текущую директорию в путь
+# Add the current directory to the path
 import sys
 sys.path.insert(0, str(Path(__file__).parent))
 
 def test_imports():
-    """Тестируем, что все модули импортируются корректно"""
-    print("🧪 Тестирование импортов...")
+    """Test that all modules import correctly"""
+    print("🧪 Testing imports...")
     
     try:
         from manim_video_generator.gemini_client import GeminiClient
-        print("✅ GeminiClient импортирован")
+        print("✅ GeminiClient imported")
     except ImportError as e:
-        print(f"❌ Ошибка импорта GeminiClient: {e}")
+        print(f"❌ GeminiClient import error: {e}")
         return False
     
     try:
         from manim_video_generator.video_executor import VideoExecutor
-        print("✅ VideoExecutor импортирован")
+        print("✅ VideoExecutor imported")
     except ImportError as e:
-        print(f"❌ Ошибка импорта VideoExecutor: {e}")
+        print(f"❌ VideoExecutor import error: {e}")
         return False
     
     try:
         from manim_video_generator.cli import generate
-        print("✅ CLI импортирован")
+        print("✅ CLI imported")
     except ImportError as e:
-        print(f"❌ Ошибка импорта CLI: {e}")
+        print(f"❌ CLI import error: {e}")
         return False
     
     return True
 
 def test_video_executor():
-    """Тестируем VideoExecutor без реального выполнения"""
-    print("\n🧪 Тестирование VideoExecutor...")
+    """Test VideoExecutor without actual execution"""
+    print("\n🧪 Testing VideoExecutor...")
     
     try:
         from manim_video_generator.video_executor import VideoExecutor
         
-        # Создаем экземпляр
+        # Create an instance
         executor = VideoExecutor(output_dir="test_output")
-        print("✅ VideoExecutor создан успешно")
+        print("✅ VideoExecutor created successfully")
         
-        # Проверяем, что папка создалась
+        # Check that the folder was created
         if Path("test_output").exists():
-            print("✅ Папка вывода создана")
+            print("✅ Output folder created")
         else:
-            print("❌ Папка вывода не создана")
+            print("❌ Output folder not created")
             return False
             
     except Exception as e:
-        print(f"❌ Ошибка в VideoExecutor: {e}")
+        print(f"❌ VideoExecutor error: {e}")
         return False
     
     return True
 
 def test_gemini_client_init():
-    """Тестируем инициализацию GeminiClient (без API ключа)"""
-    print("\n🧪 Тестирование GeminiClient (без API)...")
+    """Test GeminiClient initialization (without API key)"""
+    print("\n🧪 Testing GeminiClient (without API)...")
     
     try:
         from manim_video_generator.gemini_client import GeminiClient
         
-        # Тестируем ошибку без API ключа
+        # Expect an error without API key
         try:
             client = GeminiClient()
-            print("❌ GeminiClient не должен инициализироваться без API ключа")
+            print("❌ GeminiClient should not initialize without API key")
             return False
         except ValueError as e:
             if "GEMINI_API_KEY" in str(e):
-                print("✅ Корректная проверка API ключа")
+                print("✅ Correct API key check")
             else:
-                print(f"❌ Неожиданная ошибка: {e}")
+                print(f"❌ Unexpected error: {e}")
                 return False
                 
     except Exception as e:
-        print(f"❌ Ошибка в GeminiClient: {e}")
+        print(f"❌ GeminiClient error: {e}")
         return False
     
     return True
 
 def main():
-    print("🚀 Запуск тестов Manim Video Generator\n")
+    print("🚀 Running Manim Video Generator tests\n")
     
     all_passed = True
     
@@ -95,14 +95,14 @@ def main():
     all_passed &= test_video_executor()
     all_passed &= test_gemini_client_init()
     
-    print("\n" + "="*50)
+    print("\n" + "=" * 50)
     if all_passed:
-        print("🎉 Все тесты прошли успешно!")
-        print("\nДля полного тестирования:")
-        print("1. Установите API ключ Gemini в .env файл")
-        print("2. Запустите: manim-generate 'простая анимация'")
+        print("🎉 All tests passed!")
+        print("\nFor full testing:")
+        print("1. Put your Gemini API key in the .env file")
+        print("2. Run: manim-generate 'simple animation'")
     else:
-        print("❌ Некоторые тесты не прошли")
+        print("❌ Some tests failed")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/test_manim_execution.py
+++ b/test_manim_execution.py
@@ -1,59 +1,59 @@
 """
-Тестирование VideoExecutor с простым кодом Manim
+Test VideoExecutor with simple Manim code
 """
 
 from manim_video_generator.video_executor import VideoExecutor
 from pathlib import Path
 
-# Простой тестовый код Manim
+# Simple Manim test code
 test_code = '''
 from manim import *
 
 class VideoScene(Scene):
     def construct(self):
-        # Создаем простой текст
+        # Create a simple text
         title = Text("Hello, Manim!", font_size=48)
-        
-        # Показываем текст
+
+        # Show the text
         self.play(Write(title))
         self.wait(1)
-        
-        # Создаем квадрат
+
+        # Create a square
         square = Square(color=BLUE)
-        
-        # Перемещаем текст вверх и показываем квадрат
+
+        # Move the text up and show the square
         self.play(
             title.animate.to_edge(UP),
             Create(square)
         )
         self.wait(1)
-        
-        # Поворачиваем квадрат
+
+        # Rotate the square
         self.play(Rotate(square, PI/2))
         self.wait(1)
 '''
 
 def main():
-    print("🧪 Тестирование VideoExecutor с простым кодом Manim")
+    print("🧪 Testing VideoExecutor with simple Manim code")
     
     try:
-        # Создаем executor
+        # Create executor
         executor = VideoExecutor(output_dir="test_output")
-        
-        print("📝 Выполняем тестовый код...")
+
+        print("📝 Running test code...")
         video_path = executor.execute_manim_code(test_code)
-        
-        print(f"✅ Видео создано успешно: {video_path}")
-        
-        # Проверяем, что файл существует
+
+        print(f"✅ Video created successfully: {video_path}")
+
+        # Check that the file exists
         if video_path.exists():
             size_mb = video_path.stat().st_size / (1024 * 1024)
-            print(f"📊 Размер файла: {size_mb:.1f} MB")
+            print(f"📊 File size: {size_mb:.1f} MB")
         else:
-            print("❌ Файл не найден")
+            print("❌ File not found")
             
     except Exception as e:
-        print(f"❌ Ошибка: {e}")
+        print(f"❌ Error: {e}")
         import traceback
         traceback.print_exc()
 


### PR DESCRIPTION
## Summary
- add Gemini-driven code fixing capability
- implement interactive error loop in CLI when manim fails
- bump package version to 1.1.0
- translate all prompts and user-facing text to English

## Testing
- `python test_example.py` *(fails: No module named 'google.generativeai')*
- `python test_manim_execution.py` *(fails: ModuleNotFoundError: No module named 'loguru')*