### PR TITLE
Add rendering progress notice

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -108,6 +108,9 @@ async def coding_cycle(state: "Session", history: List[Tuple[str, str]], prompt)
             continue
 
         try:
+            append_bot_chunk(history, "\n⏳ Rendering... It can take a few minutes")
+            yield history, state, state.last_video
+            await asyncio.sleep(0)
             video_path = video_executor.execute_manim_code(py_code)
             state.last_video = video_path
         except Exception as e:


### PR DESCRIPTION
## Summary
- notify user that rendering may take a few minutes

## Testing
- `python -m py_compile demo.py manim_video_generator/*.py prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_6843d15d8f188323b5875179d7f1dc60